### PR TITLE
feat(stack.yaml,hie.yml) add stack support

### DIFF
--- a/hearts/hie.yaml
+++ b/hearts/hie.yaml
@@ -1,7 +1,25 @@
 cradle:
-  cabal:
-    - component: "lib:hearts"
-      path: "./src"
-    - component: "exe:server"
-      path: "./app"
+  stack:
+    - path: "./src"
+      component: "hearts:lib"
 
+    - path: "./app/Main.hs"
+      component: "hearts:exe:server"
+
+    - path: "./app/Args.hs"
+      component: "hearts:exe:server"
+
+    - path: "./app/Serialization.hs"
+      component: "hearts:exe:server"
+
+    - path: "./app/PlayerServer.hs"
+      component: "hearts:exe:server"
+
+    - path: "./app/TableServer.hs"
+      component: "hearts:exe:server"
+#  if you use cabal: replace above stack configuration with the following one:
+#  cabal:
+#    - component: "lib:hearts"
+#      path: "./src"
+#    - component: "exe:server"
+#      path: "./app"

--- a/hearts/hie.yaml
+++ b/hearts/hie.yaml
@@ -2,20 +2,7 @@ cradle:
   stack:
     - path: "./src"
       component: "hearts:lib"
-
-    - path: "./app/Main.hs"
-      component: "hearts:exe:server"
-
-    - path: "./app/Args.hs"
-      component: "hearts:exe:server"
-
-    - path: "./app/Serialization.hs"
-      component: "hearts:exe:server"
-
-    - path: "./app/PlayerServer.hs"
-      component: "hearts:exe:server"
-
-    - path: "./app/TableServer.hs"
+    - path: "./app"
       component: "hearts:exe:server"
 #  if you use cabal: replace above stack configuration with the following one:
 #  cabal:

--- a/hearts/stack.yaml
+++ b/hearts/stack.yaml
@@ -1,0 +1,9 @@
+resolver: lts-16.20
+
+packages:
+- .
+
+extra-deps:
+    - polysemy-1.4.0.0
+    - polysemy-plugin-0.2.5.2
+    - servant-options-0.1.0.0


### PR DESCRIPTION
### What
Add stack support

### Why
The students at the workshop use stack

### How
1. add `stack.yaml` including missing extra-dependencies not contained in the resolver.
2. update `hie.yaml` to work with stack

### Note
1. It's not possible to add both a cabal and stack configuration to `hie.yaml` so users need to (un)comment the lines according to the build tool they use.
2. I don't know about the docker stuff, but at least all plugins that our students use work as does `stack run`. See the following screenshot. Is that enough to get the students to start the project? Most of them surely won't have docker nor elm.

![image](https://user-images.githubusercontent.com/7101032/105638010-c470b180-5e70-11eb-99ab-5a5bb59dddca.png)
 